### PR TITLE
moved ServiceConfig validation into constructor

### DIFF
--- a/boardwhite/leetcode.go
+++ b/boardwhite/leetcode.go
@@ -19,7 +19,7 @@ func (s *Service) PublishLCDaily(ctx context.Context) error {
 		return fmt.Errorf("get link: %w", err)
 	}
 
-	stickerID, err := iter.PickRandom(s.cfg.DailyStickersIDs)
+	stickerID, err := iter.PickRandom(s.cfg.dailyStickersIDs)
 	if err != nil {
 		return fmt.Errorf("get sticker: %w", err)
 	}

--- a/boardwhite/mock.go
+++ b/boardwhite/mock.go
@@ -24,7 +24,7 @@ func (s *Service) OnMock(ctx context.Context, c tele.Context) error {
 	}
 
 	username := sender.Username
-	cfg, ok := s.cfg.Mocks[username]
+	cfg, ok := s.cfg.mocks[username]
 	if !ok {
 		return nil
 	}

--- a/boardwhite/neetcode.go
+++ b/boardwhite/neetcode.go
@@ -17,7 +17,7 @@ import (
 )
 
 func (s *Service) PublishNCDaily(ctx context.Context) error {
-	dayIndex := int(time.Since(s.cfg.DailyNCStartDate).Hours()/24) % neetcode.QuestionsTotalCount
+	dayIndex := int(time.Since(s.cfg.dailyNCStartDate).Hours()/24) % neetcode.QuestionsTotalCount
 	groups, err := neetcode.Groups()
 	if err != nil {
 		return fmt.Errorf("read groups: %w", err)
@@ -46,9 +46,9 @@ func (s *Service) PublishNCDaily(ctx context.Context) error {
 
 	var stickerID string
 	if group.Name == "1-D DP" || group.Name == "2-D DP" {
-		stickerID = s.cfg.DpStickerID
+		stickerID = s.cfg.dpStickerID
 	} else {
-		stickerID, err = iter.PickRandom(s.cfg.DailyStickersIDs)
+		stickerID, err = iter.PickRandom(s.cfg.dailyStickersIDs)
 		if err != nil {
 			return fmt.Errorf("get sticker: %w", err)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -78,13 +78,13 @@ func (cfg Config) ServiceConfig() (boardwhite.ServiceConfig, error) {
 		}
 	}
 
-	return boardwhite.ServiceConfig{
-		LeetcodeThreadID: cfg.Boardwhite.LeetCodeThreadID,
-		DailyStickersIDs: cfg.DailyStickerIDs,
-		DpStickerID:      cfg.DPStickerID,
-		DailyNCStartDate: ncDailyStartDate,
-		Mocks:            mocks,
-	}, nil
+	return boardwhite.NewServiceConfig(
+		cfg.Boardwhite.LeetCodeThreadID,
+		cfg.DailyStickerIDs,
+		cfg.DPStickerID,
+		ncDailyStartDate,
+		mocks,
+	)
 }
 
 func Default() (cfg Config, err error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -42,16 +42,16 @@ func TestConfigMocks(t *testing.T) {
 	cfg, err := Default()
 	require.NoError(t, err)
 
-	bwCfg, err := cfg.ServiceConfig()
-	require.NoError(t, err)
-
-	assert.NotEmpty(t, bwCfg.Mocks)
-	for username, v := range bwCfg.Mocks {
-		assert.NotEmpty(t, username)
+	assert.NotEmpty(t, cfg.Mocks)
+	for _, v := range cfg.Mocks {
+		assert.NotEmpty(t, v.Username)
 		assert.NotEmpty(t, v.Period)
 		assert.NotEmpty(t, v.StickerIDs)
 		for _, id := range v.StickerIDs {
 			assert.NotEmpty(t, id)
 		}
 	}
+
+	_, err = cfg.ServiceConfig()
+	require.NoError(t, err)
 }

--- a/drone/bot.go
+++ b/drone/bot.go
@@ -30,7 +30,7 @@ func NewBoarDWhiteServiceFromConfig(
 	telegram tg.Client,
 	database db.DB,
 	cfg boardwhite.ServiceConfig,
-) (*boardwhite.Service, error) {
+) *boardwhite.Service {
 	return boardwhite.NewService(
 		cfg,
 		telegram,
@@ -54,10 +54,8 @@ func StartDrone(ctx context.Context, cfg config.Config) error {
 	if err != nil {
 		return fmt.Errorf("service config: %w", err)
 	}
-	bw, err := NewBoarDWhiteServiceFromConfig(tgService, database, bwCfg)
-	if err != nil {
-		return err
-	}
+
+	bw := NewBoarDWhiteServiceFromConfig(tgService, database, bwCfg)
 
 	bw.RegisterHandlers(ctx, tgService)
 	tgService.Start()

--- a/drone/bot_e2e_test.go
+++ b/drone/bot_e2e_test.go
@@ -25,8 +25,8 @@ func TestDrone(t *testing.T) {
 
 	bwCfg, err := cfg.ServiceConfig()
 	require.NoError(t, err)
-	bw, err := NewBoarDWhiteServiceFromConfig(tgService, database, bwCfg)
-	require.NoError(t, err)
+
+	bw := NewBoarDWhiteServiceFromConfig(tgService, database, bwCfg)
 
 	err = bw.PublishLCDaily(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
- moved ServiceConfig validation into constructor to prevent ability to create unvalidated config